### PR TITLE
Fix screen memory leaks by deleting old screens

### DIFF
--- a/brightness_manager.cpp
+++ b/brightness_manager.cpp
@@ -2,6 +2,7 @@
 #include <driver/ledc.h>
 #include <EEPROM.h>
 #include "config.h"
+#include "screen_utils.h"
 
 extern void lv_setting_box();
 extern int saved_brightness;
@@ -70,7 +71,7 @@ void brightness_slider_event_cb(lv_event_t * e) {
 void lv_open_brightness_screen(int default_percent)
 {
     lv_obj_t * scr = lv_obj_create(NULL);
-    lv_scr_load(scr);
+    lv_load_and_delete(scr);
 
     lv_obj_set_flex_flow(scr, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(scr, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
@@ -102,7 +103,7 @@ void lv_open_brightness_screen(int default_percent)
 
     lv_obj_add_event_cb(btn_back, [](lv_event_t * e) {
         lv_obj_t *setting_screen = lv_obj_create(NULL);
-        lv_scr_load(setting_screen);
+        lv_load_and_delete(setting_screen);
         lv_setting_box(); // Mở lại màn hình Setting
     }, LV_EVENT_CLICKED, NULL);
 

--- a/screen_utils.h
+++ b/screen_utils.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <lvgl.h>
+
+static inline void lv_load_and_delete(lv_obj_t *new_screen)
+{
+    lv_obj_t *old_screen = lv_scr_act();
+    lv_scr_load(new_screen);
+    if (old_screen && old_screen != new_screen) {
+        lv_obj_del(old_screen);
+    }
+}

--- a/wifi_manager.cpp
+++ b/wifi_manager.cpp
@@ -4,6 +4,7 @@
 #include "wifi_manager.h"
 #include "style_msgbox.h"
 #include "resources.h"
+#include "screen_utils.h"
 
 // Biến toàn cục
 lv_obj_t *wifi_icon = nullptr;
@@ -247,7 +248,7 @@ static void back_btn_event_handler(lv_event_t *e) {
     WiFi.scanDelete();
     extern void lv_setting_box();
     lv_obj_t *setting_screen = lv_obj_create(NULL);
-    lv_scr_load(setting_screen);
+    lv_load_and_delete(setting_screen);
     lv_setting_box();
 }
 
@@ -269,7 +270,7 @@ static void refresh_btn_event_handler(lv_event_t *e) {
 // Tạo màn hình quét WiFi
 void create_wifi_scan_screen() {
     lv_obj_t *screen = lv_obj_create(NULL);
-    lv_scr_load(screen);
+    lv_load_and_delete(screen);
 
     lv_obj_t *title = lv_label_create(screen);
     lv_label_set_text(title, "WiFi Networks");


### PR DESCRIPTION
## Summary
- add helper `lv_load_and_delete` to replace active screen and free the previous one
- use helper when opening the brightness screen and WiFi scanning screen
- include new helper in relevant sources

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec75a4af883289e272ead53ab9047