### PR TITLE
Fix wifi header usage in style screen

### DIFF
--- a/style_msgbox.cpp
+++ b/style_msgbox.cpp
@@ -1,9 +1,9 @@
 #include "style_msgbox.h"
 #include "brightness_16.h"
+#include "wifi_manager.h"
 
 extern void lv_create_main_gui(void);
 extern void lv_setting_box(void);
-extern void create_wifi_scan_screen(void);
 extern void lv_open_brightness_screen(int default_percent);
 extern int saved_brightness;
 


### PR DESCRIPTION
## Summary
- include wifi_manager.h in style_msgbox.cpp
- remove manual declaration of `create_wifi_scan_screen`

## Testing
- `g++ -c style_msgbox.cpp` *(fails: lvgl.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed46611c8832891ced6a377403b1f