### PR TITLE
Generalize screen switch via async call

### DIFF
--- a/style_msgbox.cpp
+++ b/style_msgbox.cpp
@@ -135,8 +135,10 @@ static inline void lv_load_and_delete(lv_obj_t *new_screen)
     }
 }
 
-void lv_switch_screen(screen_id_t id)
+static void switch_screen_cb(void *user_data)
 {
+    screen_id_t id = static_cast<screen_id_t>((uintptr_t)user_data);
+
     lv_obj_t *scr = lv_obj_create(NULL);
     lv_load_and_delete(scr);
 
@@ -156,5 +158,10 @@ void lv_switch_screen(screen_id_t id)
         default:
             break;
     }
+}
+
+void lv_switch_screen(screen_id_t id)
+{
+    lv_async_call(switch_screen_cb, (void *)(uintptr_t)id);
 }
 


### PR DESCRIPTION
## Summary
- switch `lv_switch_screen` to always use `lv_async_call`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ed6c8a2888328b444640e685ece3f