### PR TITLE
Fix screen deletion order

### DIFF
--- a/style_msgbox.cpp
+++ b/style_msgbox.cpp
@@ -131,7 +131,8 @@ static inline void lv_load_and_delete(lv_obj_t *new_screen)
     lv_obj_t *old_screen = lv_scr_act();
     lv_scr_load(new_screen);
     if (old_screen && old_screen != new_screen) {
-        lv_obj_del(old_screen);
+        lv_async_call([](void *scr){ lv_obj_del((lv_obj_t *)scr); },
+                      old_screen);
     }
 }
 


### PR DESCRIPTION
## Summary
- use `lv_async_call` to delete old screen after the new one loads

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684edff0c5a883288cd0ded9fac86b00